### PR TITLE
fix: remove key error when running on non pull request

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -163,10 +163,11 @@ def get_push_event_details() -> dict:
     push_event = None
 
     github_event = get_github_event()
-    if github_event["pull_request"]:
+    try:
         # set sha to the head sha of the pull request
         github_sha = github_event["pull_request"]["head"]["sha"]
-    else:
+    except KeyError:
+        # not a pull request event
         github_sha = os.environ["GITHUB_SHA"]
 
     for event in response.json():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,3 +127,20 @@ def latest_commit(github_token):
     commit = data[0]['sha']
     os.environ['GITHUB_SHA'] = commit
     return commit
+
+
+@pytest.fixture(scope='function', params=[True, False])
+def github_event_path(request):
+    # true is original file from GitHub context
+    # false is dummy file
+
+    original_value = os.environ['GITHUB_EVENT_PATH']
+    if request.param:
+        yield
+    else:
+        os.environ['GITHUB_EVENT_PATH'] = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'dummy_github_event.json'
+        )
+        yield
+        os.environ['GITHUB_EVENT_PATH'] = original_value

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -47,7 +47,7 @@ def test_get_repo_default_branch(github_token):
     assert main.get_repo_default_branch() == 'master'
 
 
-def test_get_push_event_details(latest_commit):
+def test_get_push_event_details(github_event_path, latest_commit):
     assert main.get_push_event_details()
 
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The action would fail if the event was not a pull request. This PR fixes that.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
