### PR TITLE
feat: add tag prefix option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,31 @@ jobs:
               echo "changelog_version does not match expected"
               exit 1
           fi
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Action
+        id: setup-release
+        uses: ./
+        with:
+          fail_on_events_api_error: true
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Create Release
+        id: action
+        uses: LizardByte/create-release-action@master
+        with:
+          allowUpdates: false
+          artifacts: ''
+          body: ''
+          discussionCategory: announcements
+          generateReleaseNotes: true
+          name: ${{ steps.setup-release.outputs.release_tag }}
+          prerelease: ${{ steps.setup-release.outputs.publish_stable_release != 'True' }}
+          tag: ${{ steps.setup-release.outputs.release_tag }}
+          token: ${{ secrets.GH_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ The action does the following:
 ```
 
 ## Inputs
-| Name                     | Description                                                  | Default        | Required |
-|--------------------------|--------------------------------------------------------------|----------------|----------|
-| changelog_path           | The path to the changelog file                               | `CHANGELOG.md` | `false`  |
-| fail_on_events_api_error | Fail if the action cannot find this commit in the events API | `false`        | `false`  |
-| github_token             | The GitHub token to use for API calls                        |                | `true`   |
+| Name                         | Description                                                                                                                                            | Default        | Required |
+|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
+| changelog_path               | The path to the changelog file                                                                                                                         | `CHANGELOG.md` | `false`  |
+| fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `false`        | `false`  |
+| github_token                 | The GitHub token to use for API calls                                                                                                                  |                | `true`   |
+| include_tag_prefix_in_output | Whether to include the tag prefix in the output.                                                                                                       | `true`         | `false`  |
+| tag_prefix                   | The tag prefix. This will be used when searching for existing releases in GitHub API. This should not be included in the version within the changelog. | `v`            | `false`  |
 
 ## Outputs
 | Name                     | Description                                                                      |

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,16 @@ inputs:
   github_token:
     description: "GitHub token to use for API requests."
     required: true
+  include_tag_prefix_in_output:
+    description: "Whether to include the tag prefix in the output."
+    default: 'true'
+    required: false
+  tag_prefix:
+    description: |
+      The tag prefix. This will be used when searching for existing releases in GitHub API.
+      This should not be included in the version within the changelog.
+    default: "v"
+    required: false
 
 outputs:
   changelog_changes:

--- a/action/main.py
+++ b/action/main.py
@@ -94,7 +94,8 @@ def check_release(version: str) -> bool:
         True if the release exists, False otherwise.
     """
     # Get the release from the GitHub API
-    github_api_url = f'https://api.github.com/repos/{REPOSITORY_NAME}/releases/tags/v{version}'
+    version_prefix = os.getenv('INPUT_TAG_PREFIX', 'v')
+    github_api_url = f'https://api.github.com/repos/{REPOSITORY_NAME}/releases/tags/{version_prefix}{version}'
     response = requests.get(github_api_url, headers=GITHUB_HEADERS)
 
     # Check if the release exists
@@ -343,9 +344,13 @@ def main() -> dict:
         release_build = push_event_details["release_build"]
         release_tag = f"{release_version}"
 
+    version_prefix = ''
+    if os.getenv('INPUT_INCLUDE_TAG_PREFIX_IN_OUTPUT', 'true').lower() == 'true':
+        version_prefix = os.getenv('INPUT_TAG_PREFIX', 'v')
+
     job_outputs['release_version'] = release_version
     job_outputs['release_build'] = release_build
-    job_outputs['release_tag'] = release_tag
+    job_outputs['release_tag'] = f'{version_prefix}{release_tag}'
 
     # Set the outputs
     for output_name, output_value in job_outputs.items():


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Add tag prefix input option
- Add option to include tag prefix in output
- Create release on push to `master`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
