### PR TITLE
fix: ensure release tags are cronological

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The action does the following:
 | publish_release                | Whether or not to publish a release                                                |
 | publish_stable_release         | Whether or not to publish a stable release. The opposite of `publish_pre_release`. |
 | release_body                   | The body for the release                                                           |
-| release_build                  | The build number to identify this build (i.e. first 7 characters of commit hash)   |
+| release_build                  | The build number to identify this build (i.e. `hhmmss`)                            |
 | release_commit                 | The commit hash for the release                                                    |
 | release_generate_release_notes | Whether or not to generate release notes for the release                           |
 | release_tag                    | The tag for the release (i.e. `release_version`-`release_build`)                   |
@@ -110,7 +110,7 @@ subgraph "Set GitHub Outputs"
   B4(changelog_url = '')
   B5(changelog_version = '')
 
-  C1(release_build = \commit 0-7\)
+  C1(release_build = \hhmmss\)
   C2(release_commit = \commit\ )
 
   D1{GitHub Release Exists?}

--- a/action/main.py
+++ b/action/main.py
@@ -189,18 +189,24 @@ def get_push_event_details() -> dict:
         else:
             return push_event_details
 
-    # use regex and convert created at to yyyy.m.d
-    match = re.search(r'(\d{4})-(\d{1,2})-(\d{1,2})', push_event["created_at"])
+    # use regex and convert created at to yyyy.m.d-hhmmss
+    # created_at: "2023-1-25T10:43:35Z"
+    match = re.search(r'(\d{4})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{2}):(\d{2})Z', push_event["created_at"])
 
     release_version = ''
+    release_build = ''
     if match:
-        year = match.group(1)
-        month = match.group(2).zfill(2)  # Ensure month is zero-padded to two digits
-        day = match.group(3).zfill(2)  # Ensure day is zero-padded to two digits
+        year = int(match.group(1))
+        month = int(match.group(2))
+        day = int(match.group(3))
+        hour = match.group(4).zfill(2)
+        minute = match.group(5).zfill(2)
+        second = match.group(6).zfill(2)
         release_version = f"{year}.{month}.{day}"
+        release_build = f"{hour}{minute}{second}"
 
     push_event_details['release_version'] = release_version
-    push_event_details['release_build'] = push_event["payload"]["head"][0:7]
+    push_event_details['release_build'] = release_build
     return push_event_details
 
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Use `hhmmss` as build number instead of commit hash
- Remove padding from months and days


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
