### PR TITLE
fix!: comply with semver version syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
           echo "changelog_release_exists: ${{ steps.action.outputs.changelog_release_exists }}"
           echo "publish_stable_release: ${{ steps.action.outputs.publish_stable_release }}"
           echo "release_version: ${{ steps.action.outputs.release_version }}"
-          echo "release_build: ${{ steps.action.outputs.release_build }}"
           echo "release_tag: ${{ steps.action.outputs.release_tag }}"
 
       - name: Verify changelog_exists

--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ The action does the following:
 | publish_release                | Whether or not to publish a release                                                |
 | publish_stable_release         | Whether or not to publish a stable release. The opposite of `publish_pre_release`. |
 | release_body                   | The body for the release                                                           |
-| release_build                  | The build number to identify this build (i.e. `hhmmss`)                            |
 | release_commit                 | The commit hash for the release                                                    |
 | release_generate_release_notes | Whether or not to generate release notes for the release                           |
-| release_tag                    | The tag for the release (i.e. `release_version`-`release_build`)                   |
-| release_version                | The version for the release (i.e. `yyyy.m.d` or `changelog_version`)               |
+| release_tag                    | The tag for the release (i.e. `release_version`)                                   |
+| release_version                | The version for the release (i.e. `yyyy.mmdd.hhmmss` or `changelog_version`)       |
 
 ## Basic Flow
 ```mermaid
@@ -110,8 +109,7 @@ subgraph "Set GitHub Outputs"
   B4(changelog_url = '')
   B5(changelog_version = '')
 
-  C1(release_build = \hhmmss\)
-  C2(release_commit = \commit\ )
+  C1(release_commit = \commit\ )
 
   D1{GitHub Release Exists?}
   D2(changelog_release_exists = 'true')
@@ -120,7 +118,7 @@ subgraph "Set GitHub Outputs"
   D5(release_body = '')
   D6(release_generate_release_notes = 'true')
   D7(release_version = 'yyyy.m.d')
-  D8(release_tag = `release_version`-`release_build`)
+  D8(release_tag = `release_version`)
 
   E1(changelog_release_exists = 'false')
   E2(publish_pre_release = 'false')
@@ -149,8 +147,7 @@ B3 --> B4
 B4 --> B5
 B5 --> C1
 
-C1 --> C2
-C2--> D1
+C1--> D1
 
 D1 --> |True| D2
 D2 --> D3

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,6 @@ outputs:
     description: "Latest version in the changelog."
   publish_stable_release:
     description: "Whether to publish a stable release."
-  release_build:
-    description: "Build number of the release to make."
   release_tag:
     description: "Tag of the release to make. e.g. `vYYYY.M.D-Build` or `vYYYY.M.D`"
   release_version:

--- a/action/main.py
+++ b/action/main.py
@@ -150,7 +150,6 @@ def get_push_event_details() -> dict:
     # default
     push_event_details = dict(
         publish_release=False,
-        release_build='',
         release_commit='',
         release_version='',
     )
@@ -194,19 +193,17 @@ def get_push_event_details() -> dict:
     match = re.search(r'(\d{4})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{2}):(\d{2})Z', push_event["created_at"])
 
     release_version = ''
-    release_build = ''
     if match:
         year = int(match.group(1))
-        month = int(match.group(2))
-        day = int(match.group(3))
+        month = match.group(2).zfill(2)
+        day = match.group(3).zfill(2)
         hour = match.group(4).zfill(2)
         minute = match.group(5).zfill(2)
         second = match.group(6).zfill(2)
-        release_version = f"{year}.{month}.{day}"
-        release_build = f"{hour}{minute}{second}"
+        build = f"{hour}{minute}{second}"
+        release_version = f"{year}.{int(month)}{day}.{int(build)}"
 
     push_event_details['release_version'] = release_version
-    push_event_details['release_build'] = release_build
     return push_event_details
 
 
@@ -347,14 +344,12 @@ def main() -> dict:
         release_body = ''
         release_generate_release_notes = True
         release_version = push_event_details["release_version"]
-        release_build = push_event_details["release_build"]
-        release_tag = f"{release_version}-{release_build}"
+        release_tag = f"{release_version}"
     else:
         # the changelog release does not exist, so we want to publish a stable release
         release_body = changelog_data["changes"]
         release_generate_release_notes = False
         release_version = changelog_data["version"] if changelog_data else ''
-        release_build = push_event_details["release_build"]
         release_tag = f"{release_version}"
 
     version_prefix = ''
@@ -366,7 +361,6 @@ def main() -> dict:
     job_outputs['release_commit'] = push_event_details['release_commit']
     job_outputs['release_generate_release_notes'] = str(release_generate_release_notes).lower()
     job_outputs['release_version'] = release_version
-    job_outputs['release_build'] = release_build
     job_outputs['release_tag'] = f'{version_prefix}{release_tag}'
 
     # Set the outputs


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The PR removes the build number from the `release_tag` output, which can be interpreted as a pre-release according to semver. Complying with semver syntax is important for many tools, such as Dependabot, Renovate, NPM, etc.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
