### PR TITLE
feat: add dotnet versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The action does the following:
 | Name                         | Description                                                                                                                                            | Default        | Required |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
 | changelog_path               | The path to the changelog file                                                                                                                         | `CHANGELOG.md` | `false`  |
+| dotnet                       | Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss).                                                                             | `false`        | `false`  |
 | fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `false`        | `false`  |
 | github_token                 | The GitHub token to use for API calls                                                                                                                  |                | `true`   |
 | include_tag_prefix_in_output | Whether to include the tag prefix in the output.                                                                                                       | `true`         | `false`  |
@@ -61,7 +62,7 @@ The action does the following:
 | release_body                   | The body for the release                                                           |
 | release_commit                 | The commit hash for the release                                                    |
 | release_generate_release_notes | Whether or not to generate release notes for the release                           |
-| release_tag                    | The tag for the release (i.e. `release_version`)                                   |
+| release_tag                    | The tag for the release (i.e. `release_version` with prefix)                       |
 | release_version                | The version for the release (i.e. `yyyy.mmdd.hhmmss` or `changelog_version`)       |
 
 ## Basic Flow
@@ -117,7 +118,7 @@ subgraph "Set GitHub Outputs"
   D4(publish_stable_release = 'false')
   D5(release_body = '')
   D6(release_generate_release_notes = 'true')
-  D7(release_version = 'yyyy.m.d')
+  D7(release_version = 'yyyy.md.hhmmss')
   D8(release_tag = `release_version`)
 
   E1(changelog_release_exists = 'false')

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "Path to the changelog file, relative to the GitHub workspace."
     default: "CHANGELOG.md"
     required: false
+  dotnet:
+    description: "Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss)."
+    default: 'false'
+    required: false
   fail_on_events_api_error:
     description: "Whether to fail if the GitHub Events API returns an error."
     default: 'false'

--- a/action/main.py
+++ b/action/main.py
@@ -200,8 +200,15 @@ def get_push_event_details() -> dict:
         hour = match.group(4).zfill(2)
         minute = match.group(5).zfill(2)
         second = match.group(6).zfill(2)
-        build = f"{hour}{minute}{second}"
-        release_version = f"{year}.{int(month)}{day}.{int(build)}"
+        if os.getenv('INPUT_DOTNET', 'false').lower() == 'true':
+            # dotnet versioning
+            build = f"{hour}{minute}"
+            revision = second
+            release_version = f"{year}.{int(month)}{day}.{int(build)}.{int(revision)}"
+        else:
+            # default versioning
+            build = f"{hour}{minute}{second}"
+            release_version = f"{year}.{int(month)}{day}.{int(build)}"
 
     push_event_details['release_version'] = release_version
     return push_event_details

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,3 +144,11 @@ def github_event_path(request):
         )
         yield
         os.environ['GITHUB_EVENT_PATH'] = original_value
+
+
+@pytest.fixture(params=[True, False], scope='function')
+def input_dotnet(request):
+    os.environ['INPUT_DOTNET'] = str(request.param).lower()
+    yield
+
+    del os.environ['INPUT_DOTNET']

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -47,7 +47,7 @@ def test_get_repo_default_branch(github_token):
     assert main.get_repo_default_branch() == 'master'
 
 
-def test_get_push_event_details(github_event_path, latest_commit):
+def test_get_push_event_details(github_event_path, input_dotnet, latest_commit):
     assert main.get_push_event_details()
 
 
@@ -61,7 +61,7 @@ def test_parse_changelog(changelog_set):
         assert changelog_data['changes'] == changelog_set['changes']
 
 
-def test_main(changelog_set, github_output_file, github_step_summary_file, github_token):
+def test_main(changelog_set, github_output_file, github_step_summary_file, github_token, input_dotnet):
     job_outputs = main.main()
 
     with open(github_output_file, 'r') as f:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add an input option to setup a version number for dotnot projects (e.g. Themerr-jellyfin).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
