### PR TITLE
fix: change default value of fail_on_events_api_error to true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
         uses: ./
         with:
           changelog_path: ./tests/data/set${{ matrix.set }}/CHANGELOG.md
-          fail_on_events_api_error: false
+          fail_on_events_api_error:  # PRs will fail if this is true
+            ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print action outputs

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The action does the following:
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
 | changelog_path               | The path to the changelog file                                                                                                                         | `CHANGELOG.md` | `false`  |
 | dotnet                       | Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss).                                                                             | `false`        | `false`  |
-| fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `false`        | `false`  |
+| fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `true`         | `false`  |
 | github_token                 | The GitHub token to use for API calls                                                                                                                  |                | `true`   |
 | include_tag_prefix_in_output | Whether to include the tag prefix in the output.                                                                                                       | `true`         | `false`  |
 | tag_prefix                   | The tag prefix. This will be used when searching for existing releases in GitHub API. This should not be included in the version within the changelog. | `v`            | `false`  |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
   fail_on_events_api_error:
     description: "Whether to fail if the GitHub Events API returns an error."
-    default: 'false'
+    default: 'true'
     required: false
   github_token:
     description: "GitHub token to use for API requests."


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Change default value of `fail_on_events_api_error` from `false` to `true`.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
