### PR TITLE
feat: add retry options for events api

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The action does the following:
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
 | changelog_path               | The path to the changelog file                                                                                                                         | `CHANGELOG.md` | `false`  |
 | dotnet                       | Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss).                                                                             | `false`        | `false`  |
+| event_api_max_attempts       | Maximum number of attempts for the GitHub Events API.                                                                                                  | `5`            | `false`  |
 | fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `true`         | `false`  |
 | github_token                 | The GitHub token to use for API calls                                                                                                                  |                | `true`   |
 | include_tag_prefix_in_output | Whether to include the tag prefix in the output.                                                                                                       | `true`         | `false`  |

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss)."
     default: 'false'
     required: false
+  event_api_max_attempts:
+    description: "Maximum number of attempts for the GitHub Events API."
+    default: '5'
+    required: false
   fail_on_events_api_error:
     description: "Whether to fail if the GitHub Events API returns an error."
     default: 'true'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,13 @@ os.environ['GITHUB_OUTPUT'] = 'github_output.md'
 os.environ['GITHUB_STEP_SUMMARY'] = 'github_step_summary.md'
 os.environ['GITHUB_WORKSPACE'] = os.path.join(os.getcwd(), 'github', 'workspace')
 os.environ['INPUT_CHANGELOG_PATH'] = 'CHANGELOG.md'
+os.environ['INPUT_EVENT_API_MAX_ATTEMPTS'] = '1'
 
 try:
     GITHUB_TOKEN = os.environ['INPUT_GITHUB_TOKEN']
 except KeyError:
-    GITHUB_TOKEN = os.environ['INPUT_GITHUB_TOKEN'] = ''
+    os.environ['INPUT_GITHUB_TOKEN'] = ''
+    GITHUB_TOKEN = os.environ['INPUT_GITHUB_TOKEN']
 
 GITHUB_HEADERS = {'Authorization': f'token {GITHUB_TOKEN}'}
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add a retry loop for GitHub events API, since it may take a little bit of time before a commit appears there.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
