### PR TITLE
fix: github events api error can ony fail for push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,6 @@ jobs:
         uses: ./
         with:
           changelog_path: ./tests/data/set${{ matrix.set }}/CHANGELOG.md
-          fail_on_events_api_error:  # PRs will fail if this is true
-            ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print action outputs
@@ -147,7 +145,6 @@ jobs:
         id: setup-release
         uses: ./
         with:
-          fail_on_events_api_error: true
           github_token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Create Release

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The action does the following:
 ## Inputs
 | Name                         | Description                                                                                                                                            | Default        | Required |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------|
-| changelog_path               | The path to the changelog file                                                                                                                         | `CHANGELOG.md` | `false`  |
+| changelog_path               | Path to the changelog file, relative to the GitHub workspace.                                                                                          | `CHANGELOG.md` | `false`  |
 | dotnet                       | Whether to create a dotnet version (4 components, e.g. yyyy.mmdd.hhmm.ss).                                                                             | `false`        | `false`  |
 | event_api_max_attempts       | Maximum number of attempts for the GitHub Events API.                                                                                                  | `5`            | `false`  |
-| fail_on_events_api_error     | Fail if the action cannot find this commit in the events API                                                                                           | `true`         | `false`  |
-| github_token                 | The GitHub token to use for API calls                                                                                                                  |                | `true`   |
+| fail_on_events_api_error     | Whether to fail if the GitHub Events API returns an error. Will only fail for push events.                                                             | `true`         | `false`  |
+| github_token                 | GitHub token to use for API requests.                                                                                                                  |                | `true`   |
 | include_tag_prefix_in_output | Whether to include the tag prefix in the output.                                                                                                       | `true`         | `false`  |
 | tag_prefix                   | The tag prefix. This will be used when searching for existing releases in GitHub API. This should not be included in the version within the changelog. | `v`            | `false`  |
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: '5'
     required: false
   fail_on_events_api_error:
-    description: "Whether to fail if the GitHub Events API returns an error."
+    description: "Whether to fail if the GitHub Events API returns an error. Will only fail for push events."
     default: 'true'
     required: false
   github_token:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -51,6 +51,17 @@ def test_get_push_event_details(github_event_path, input_dotnet, latest_commit):
     assert main.get_push_event_details()
 
 
+def test_get_push_event_details_no_event(dummy_github_event_path, dummy_commit):
+    result = main.get_push_event_details()
+    assert result['publish_release'] is False
+    assert result['release_version'] == ''
+
+
+def test_get_push_event_details_fail_on_error(dummy_github_event_path, dummy_commit, fail_on_events_api_error):
+    with pytest.raises(SystemExit):
+        main.get_push_event_details()
+
+
 def test_parse_changelog(changelog_set):
     if changelog_set['changelog_expected']:
         changelog_data = main.parse_changelog(changelog_path=changelog_set['changelog_path'])


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Only allow failing for events api errors, if it is not a pull request event.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
