### PR TITLE
fix: ensure pytest passes for pull request and push events

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ def changelog_set(request):
 @pytest.fixture(scope='function')
 def latest_commit(github_token):
     global COMMIT
+    original_sha = os.environ.get('GITHUB_SHA', '')
 
     if not COMMIT:
         # get commits on the default branch
@@ -138,15 +139,16 @@ def latest_commit(github_token):
     os.environ['GITHUB_SHA'] = COMMIT
     yield COMMIT
 
-    del os.environ['GITHUB_SHA']
+    os.environ['GITHUB_SHA'] = original_sha
 
 
 @pytest.fixture(scope='function')
 def dummy_commit():
+    original_sha = os.environ.get('GITHUB_SHA', '')
     os.environ['GITHUB_SHA'] = 'not-a-real-commit'
     yield
 
-    del os.environ['GITHUB_SHA']
+    os.environ['GITHUB_SHA'] = original_sha
 
 
 @pytest.fixture(scope='function', params=[True, False])


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The `GITHUB_SHA` env variable was getting deleting when tearing down tests, and thus it was not available for tests that rely on it for an actual push event. With this PR the variable is restored to it's original value.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
