### PR TITLE
docs: remove legacy output from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,5 @@ The action does the following:
 |--------------------------------|--------------------------------------------------------------------|
 | publish_release                | Whether or not to publish a release                                |
 | release_commit                 | The commit hash for the release                                    |
-| release_generate_release_notes | Whether to generate release notes for the release. (Always `true`) |
 | release_tag                    | The tag for the release (i.e. `release_version` with prefix)       |
 | release_version                | The version for the release (i.e. `yyyy.mmdd.hhmmss`)              |

--- a/action/main.py
+++ b/action/main.py
@@ -133,6 +133,8 @@ def get_push_event_details() -> dict:
     )
 
     github_api_url = f'https://api.github.com/repos/{REPOSITORY_NAME}/events'
+    # this endpoint can be delayed between 30 seconds and 6 hours...
+    # https://docs.github.com/en/rest/activity/events?apiVersion=2022-11-28#list-repository-events
 
     # query parameters
     params = {


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Removes an unused output from the readme.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
