### PR TITLE
fix(action): add release_body to action config outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         shell: bash
         run: |
           echo "publish_release: ${{ steps.action.outputs.publish_release }}"
+          echo "release_body: ${{ steps.action.outputs.release_body }}"
           echo "release_commit: ${{ steps.action.outputs.release_commit }}"
           echo "release_generate_release_notes: ${{ steps.action.outputs.release_generate_release_notes }}"
           echo "release_tag: ${{ steps.action.outputs.release_tag }}"
@@ -96,7 +97,7 @@ jobs:
 
       - name: Create Release
         id: action
-        uses: LizardByte/create-release-action@master  # keep this on master, to prevent endless depandabot PRs
+        uses: LizardByte/create-release-action@master  # keep this on master, to prevent endless dependabot PRs
         with:
           allowUpdates: false
           artifacts: ''

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
 outputs:
   publish_release:
     description: "Whether to publish a release."
+  release_body:
+    description: "The body for the release."
   release_commit:
     description: "The commit hash for the release."
   release_generate_release_notes:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`release_body` was missing from the `action.yml` outputs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
