### PR TITLE
fix: handle multiple timestamp formats

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -1,4 +1,5 @@
 # standard imports
+from datetime import datetime
 import io
 import json
 import os
@@ -209,16 +210,17 @@ def get_push_event_details() -> dict:
     commit_timestamp = github_event["commits"][0]['timestamp']
 
     # use regex and convert created at to yyyy.m.d-hhmmss
+    # GitHub can provide timestamps in different formats, ensure we handle them all using `fromisoformat`
     # timestamp: "2023-01-25T10:43:35Z"
-    match = re.search(r'(\d{4})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{2}):(\d{2})Z', commit_timestamp)
+    # timestamp "2024-07-14T13:17:25-04:00"
+    timestamp = datetime.fromisoformat(commit_timestamp)
+    year = timestamp.year
+    month = str(timestamp.month).zfill(2)
+    day = str(timestamp.day).zfill(2)
+    hour = str(timestamp.hour).zfill(2)
+    minute = str(timestamp.minute).zfill(2)
+    second = str(timestamp.second).zfill(2)
 
-    # assume a match, and raise exception if not found
-    year = int(match.group(1))
-    month = match.group(2).zfill(2)
-    day = match.group(3).zfill(2)
-    hour = match.group(4).zfill(2)
-    minute = match.group(5).zfill(2)
-    second = match.group(6).zfill(2)
     if os.getenv('INPUT_DOTNET', 'false').lower() == 'true':
         # dotnet versioning
         build = f"{hour}{minute}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,20 +116,11 @@ def dummy_github_push_event_path_invalid_commits():
     os.environ['GITHUB_EVENT_PATH'] = original_value
 
 
-@pytest.fixture(scope='function', params=[True, False])
-def github_event_path(request, dummy_github_pr_event_path, dummy_github_push_event_path):
-    # true is PR event
-    # false is push event
-
+@pytest.fixture(scope='function', params=['pr', 'push', 'push_alt_timestamp'])
+def github_event_path(request):
     original_value = os.getenv('GITHUB_EVENT_PATH', os.path.join(DATA_DIRECTORY, 'dummy_github_event.json'))
-
-    if request.param:
-        os.environ['GITHUB_EVENT_PATH'] = os.path.join(DATA_DIRECTORY, 'dummy_github_pr_event.json')
-        yield
-    else:
-        os.environ['GITHUB_EVENT_PATH'] = os.path.join(DATA_DIRECTORY, 'dummy_github_push_event.json')
-        yield
-
+    os.environ['GITHUB_EVENT_PATH'] = os.path.join(DATA_DIRECTORY, f'dummy_github_{request.param}_event.json')
+    yield
     os.environ['GITHUB_EVENT_PATH'] = original_value
 
 

--- a/tests/data/dummy_github_push_alt_timestamp_event.json
+++ b/tests/data/dummy_github_push_alt_timestamp_event.json
@@ -1,0 +1,10 @@
+{
+  "repository": {
+    "default_branch": "master"
+  },
+  "commits": [
+    {
+      "timestamp": "2023-07-14T13:17:25-04:00"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes an issue where GitHub could provide timestamps in different formats when using commits from the push event context instead of the events API (see: #107).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
