### PR TITLE
fix(changelog): resolve issue when `@` symbol appears earlier in entry than the contributor

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -256,8 +256,10 @@ def process_release_body(release_body: str) -> str:
     re_username = re.compile(r'@([a-zA-Z\d\-]{0,38})')
     re_pr_url = re.compile(r'(https://github\.com/([a-zA-Z\d\-]{0,38})/([a-zA-Z\d-]+)/pull/(\d+))')
     for line in io.StringIO(release_body).readlines():
+        split_line = line.rsplit(' by ', 1)
+
         # find the username
-        username_search = re_username.search(line)
+        username_search = re_username.search(split_line[1] if len(split_line) > 1 else line)
         if not username_search:
             processed_body += line
             continue

--- a/tests/data/expected_release_notes_sample_1.md
+++ b/tests/data/expected_release_notes_sample_1.md
@@ -1,5 +1,6 @@
 ## What's Changed
 * test: Test coverage by not providing a PR URL by [@LizardByte](https://github.com/LizardByte)
+* build(deps): bump @fortawesome/fontawesome-free from 6.5.1 to 6.5.2 by [@dependabot](https://github.com/dependabot) in [#412](https://github.com/LizardByte/Themerr-plex/pull/412)
 
 ## New Contributors
 * [@LizardByte](https://github.com/LizardByte) made their first contribution

--- a/tests/data/provided_release_notes_sample_1.md
+++ b/tests/data/provided_release_notes_sample_1.md
@@ -1,5 +1,6 @@
 ## What's Changed
 * test: Test coverage by not providing a PR URL by @LizardByte
+* build(deps): bump @fortawesome/fontawesome-free from 6.5.1 to 6.5.2 by @dependabot in https://github.com/LizardByte/Themerr-plex/pull/412
 
 ## New Contributors
 * @LizardByte made their first contribution


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
In some cases the `@` symbol could appear earlier in the line, causing the regex to fail to find the username.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
