### PR TITLE
fix: ensure release version is based on UTC timezone

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,11 +1,96 @@
 # standard imports
 import os
+from typing import Dict, Tuple, Union
 
 # lib imports
 import pytest
 
 # local imports
 from action import main
+
+
+@pytest.mark.parametrize('iso_timestamp', [
+    ('1970-01-01T00:00:00Z', dict(
+        year=1970,
+        month='01',
+        day='01',
+        hour='00',
+        minute='00',
+        second='00',
+    )),
+    ('2023-11-27T23:58:28Z', dict(
+        year=2023,
+        month='11',
+        day='27',
+        hour='23',
+        minute='58',
+        second='28',
+    )),
+    ('2023-01-25T10:43:35Z', dict(
+        year=2023,
+        month='01',
+        day='25',
+        hour='10',
+        minute='43',
+        second='35',
+    )),
+    ('2024-07-14T17:17:25Z', dict(
+        year=2024,
+        month='07',
+        day='14',
+        hour='17',
+        minute='17',
+        second='25',
+    )),
+    ('2024-07-14T13:17:25-04:00', dict(
+        year=2024,
+        month='07',
+        day='14',
+        hour='17',  # include timezone offset
+        minute='17',
+        second='25',
+    )),
+    ('2024-07-14T13:17:25+04:00', dict(
+        year=2024,
+        month='07',
+        day='14',
+        hour='09',  # include timezone offset
+        minute='17',
+        second='25',
+    )),
+    ('2024-07-22T22:17:25-04:00', dict(
+        year=2024,
+        month='07',
+        day='23',
+        hour='02',  # include timezone offset
+        minute='17',
+        second='25',
+    )),
+])
+def test_timestamp_class(iso_timestamp: Tuple[str, Dict[str, Union[int, str]]]):
+    timestamp = main.TimestampUTC(iso_timestamp=iso_timestamp[0])
+
+    assert timestamp.year == iso_timestamp[1]['year']
+    assert timestamp.month == iso_timestamp[1]['month']
+    assert timestamp.day == iso_timestamp[1]['day']
+    assert timestamp.hour == iso_timestamp[1]['hour']
+    assert timestamp.minute == iso_timestamp[1]['minute']
+    assert timestamp.second == iso_timestamp[1]['second']
+
+    assert repr(timestamp) == ("TimestampUTC("
+                               f"y{iso_timestamp[1]['year']}."
+                               f"m{iso_timestamp[1]['month']}."
+                               f"d{iso_timestamp[1]['day']}."
+                               f"h{iso_timestamp[1]['hour']}."
+                               f"m{iso_timestamp[1]['minute']}."
+                               f"s{iso_timestamp[1]['second']})")
+
+    assert str(timestamp) == (f"self.year={iso_timestamp[1]['year']}, "
+                              f"self.month='{iso_timestamp[1]['month']}', "
+                              f"self.day='{iso_timestamp[1]['day']}', "
+                              f"self.hour='{iso_timestamp[1]['hour']}', "
+                              f"self.minute='{iso_timestamp[1]['minute']}', "
+                              f"self.second='{iso_timestamp[1]['second']}'")
 
 
 @pytest.mark.parametrize('message', [


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The timezone was not included when parsing the commit timestamp which could result in out of order release versions.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
